### PR TITLE
FIXED - Table modification with float numbers doesn't work #284

### DIFF
--- a/medomics.dev.js
+++ b/medomics.dev.js
@@ -4,10 +4,17 @@ export const PORT_FINDING_METHOD = {
 }
 
 const config = {
+  // If true, the server will be run automatically when the app is launched
   runServerAutomatically: true,
+  // If true, use the react dev tools
   useReactDevTools: false,
-  defaultPort: 54288,
+  // the default port to use for the server, be sure that no programs use it by default
+  defaultPort: 5000,
+  // Either "FIX" or "AVAILABLE" (case sensitive)
+  // FIX 		-­> if defaultPort is used, force terminate and use defaultPort
+  // AVAILABLE 	-> if defaultPort is used, iterate to find next available port
   portFindingMethod: PORT_FINDING_METHOD.FIX
 }
+
 
 export default config

--- a/medomics.dev.js
+++ b/medomics.dev.js
@@ -4,17 +4,10 @@ export const PORT_FINDING_METHOD = {
 }
 
 const config = {
-  // If true, the server will be run automatically when the app is launched
   runServerAutomatically: true,
-  // If true, use the react dev tools
   useReactDevTools: false,
-  // the default port to use for the server, be sure that no programs use it by default
-  defaultPort: 5000,
-  // Either "FIX" or "AVAILABLE" (case sensitive)
-  // FIX 		-­> if defaultPort is used, force terminate and use defaultPort
-  // AVAILABLE 	-> if defaultPort is used, iterate to find next available port
+  defaultPort: 54288,
   portFindingMethod: PORT_FINDING_METHOD.FIX
 }
-
 
 export default config

--- a/renderer/components/dataTypeVisualisation/dataTableWrapperBPClass.tsx
+++ b/renderer/components/dataTypeVisualisation/dataTableWrapperBPClass.tsx
@@ -1,26 +1,17 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-unused-vars */
 import * as React from "react"
-import {Button} from "primereact/button"
-import {Collapse, Divider, HotkeysTarget2, Intent, Menu, MenuItem} from "@blueprintjs/core"
+import { Button } from "primereact/button"
+import { Collapse, Divider, HotkeysTarget2, Intent, Menu, MenuItem } from "@blueprintjs/core"
 import xlxs from "xlsx"
-import {
-  Column,
-  ColumnHeaderCell,
-  CopyCellsMenuItem,
-  EditableCell2,
-  EditableName,
-  MenuContext,
-  Table2,
-  Utils
-} from "@blueprintjs/table"
-import {Stack} from "react-bootstrap"
-import {ChevronRight, FiletypeCsv, FiletypeJson, FiletypeXlsx} from "react-bootstrap-icons"
-import {PiFloppyDisk} from "react-icons/pi"
-import {toast} from "react-toastify"
-import {DataFrame, Utils as danfoUtils} from "danfojs-node"
-import {DataTablePopoverBP} from "./dataTablePopoverBPClass"
-import {deepCopy} from "../../utilities/staticFunctions"
+import { Column, ColumnHeaderCell, CopyCellsMenuItem, EditableCell2, EditableName, MenuContext, Table2, Utils } from "@blueprintjs/table"
+import { Stack } from "react-bootstrap"
+import { ChevronRight, FiletypeCsv, FiletypeJson, FiletypeXlsx } from "react-bootstrap-icons"
+import { PiFloppyDisk } from "react-icons/pi"
+import { toast } from "react-toastify"
+import { DataFrame, Utils as danfoUtils } from "danfojs-node"
+import { DataTablePopoverBP } from "./dataTablePopoverBPClass"
+import { deepCopy } from "../../utilities/staticFunctions"
 
 const dfd = require("danfojs-node")
 const dfUtils = new danfoUtils()
@@ -33,7 +24,18 @@ export type getName = (columnIndex: number) => string // function that returns t
 
 export interface SortableColumn {
   // interface for the sortable column
-  getColumn(getCellRenderer: CellLookup, getCellData: CellLookup, sortColumn: SortCallback, filterColumn: FilterCallback, nameRenderer: nameRenderer, colName: getName, getFilterValue: getName, freezeColumn: any, isFrozen: any, getReorderedIndex: (number: number) => number): JSX.Element
+  getColumn(
+    getCellRenderer: CellLookup,
+    getCellData: CellLookup,
+    sortColumn: SortCallback,
+    filterColumn: FilterCallback,
+    nameRenderer: nameRenderer,
+    colName: getName,
+    getFilterValue: getName,
+    freezeColumn: any,
+    isFrozen: any,
+    getReorderedIndex: (number: number) => number
+  ): JSX.Element
 }
 
 /**
@@ -66,7 +68,18 @@ abstract class AbstractSortableColumn implements SortableColumn {
    * @param filterColumn - function that filters the column
    * @returns JSX.Element - column
    */
-  public getColumn(getCellRenderer: CellLookup, getCellData: CellLookup, sortColumn: SortCallback, filterColumn: FilterCallback, nameRenderer: nameRenderer, getName: getName, getFilterValue: getName, freezeColumn: any, getIsFrozen: any, getReorderedIndex: (number: number) => any) {
+  public getColumn(
+    getCellRenderer: CellLookup,
+    getCellData: CellLookup,
+    sortColumn: SortCallback,
+    filterColumn: FilterCallback,
+    nameRenderer: nameRenderer,
+    getName: getName,
+    getFilterValue: getName,
+    freezeColumn: any,
+    getIsFrozen: any,
+    getReorderedIndex: (number: number) => any
+  ) {
     const menuRenderer = this.renderMenu.bind(this, sortColumn, freezeColumn, getIsFrozen) // bind the sortColumn function to the menuRenderer
     // const filterThisColumn = (filterValue: string) => filterColumn(this.index, filterValue) // bind the filterColumn function to the filterThisColumn function
     const columnHeaderCellRenderer = () => (
@@ -374,21 +387,21 @@ export class DataTableWrapperBPClass extends React.PureComponent<{}, {}> {
    * @returns modifiedData - data with updated values from sparseCellData
    */
   public getModifiedData(data: any[]) {
-    let modifiedData = [];
-    let headers = Object.keys(data[0]);
-    const { sparseCellData } = this.state;
+    let modifiedData = []
+    let headers = Object.keys(data[0])
+    const { sparseCellData } = this.state
     data.forEach((row: { [x: string]: any }, index: any) => {
-      let newRow = {};
+      let newRow = {}
       headers.forEach((header) => {
         if (sparseCellData[`${index}-${header}`]) {
-          newRow[header] = sparseCellData[`${index}-${header}`];
+          newRow[header] = sparseCellData[`${index}-${header}`]
         } else {
-          newRow[header] = row[header];
+          newRow[header] = row[header]
         }
-      });
-      modifiedData.push(newRow);
-    });
-    return modifiedData;
+      })
+      modifiedData.push(newRow)
+    })
+    return modifiedData
   }
 
   /**
@@ -669,25 +682,25 @@ export class DataTableWrapperBPClass extends React.PureComponent<{}, {}> {
    * @returns void
    */
   public async saveData(event: React.MouseEvent<HTMLButtonElement, MouseEvent>, data: any) {
-    const modifiedData = this.getModifiedData(data);
+    const modifiedData = this.getModifiedData(data)
     Object.keys(this.state.sparseCellData).forEach((dataKey: string) => {
-      const [rowIndex, columnIndex] = this.decoupleDataKey(dataKey);
-      modifiedData[rowIndex][this.state.columnsNames[columnIndex]] = this.state.sparseCellData[dataKey];
-    });
+      const [rowIndex, columnIndex] = this.decoupleDataKey(dataKey)
+      modifiedData[rowIndex][this.state.columnsNames[columnIndex]] = this.state.sparseCellData[dataKey]
+    })
 
     // Check if any value in modifiedData contains a comma, if yes, replace it with a point.
     for (let i = 0; i < modifiedData.length; i++) {
       for (let j = 0; j < this.state.columnsNames.length; j++) {
         if (modifiedData[i][this.state.columnsNames[j]].includes(",")) {
-          modifiedData[i][this.state.columnsNames[j]] = modifiedData[i][this.state.columnsNames[j]].replace(",", ".");
+          modifiedData[i][this.state.columnsNames[j]] = modifiedData[i][this.state.columnsNames[j]].replace(",", ".")
         }
       }
     }
 
-    let df = new dfd.DataFrame(modifiedData);
-    this.saveColumnsNewNames(df);
-    let finalDf = this.addTagsToData(df);
-    let finalData = dfd.toJSON(finalDf);
+    let df = new dfd.DataFrame(modifiedData)
+    this.saveColumnsNewNames(df)
+    let finalDf = this.addTagsToData(df)
+    let finalData = dfd.toJSON(finalDf)
     if (this.state.config.extension === "csv") {
       try {
         await this.exportToCSV(event, [], this.state.config.path, finalDf)
@@ -742,15 +755,36 @@ export class DataTableWrapperBPClass extends React.PureComponent<{}, {}> {
     const columns = this.state.columns.map(
       (
         col // get the columns
-      ) => col.getColumn(this.getCellRenderer, this.getCellData, this.sortColumn, this.filterColumn, this.getColumnNameRenderer, this.getColumnNameFromColumnIndex, this.getFilterValue, this.freezeColumn, this.getIsFrozen, this.getCorrectedColumnIndex)
+      ) =>
+        col.getColumn(
+          this.getCellRenderer,
+          this.getCellData,
+          this.sortColumn,
+          this.filterColumn,
+          this.getColumnNameRenderer,
+          this.getColumnNameFromColumnIndex,
+          this.getFilterValue,
+          this.freezeColumn,
+          this.getIsFrozen,
+          this.getCorrectedColumnIndex
+        )
     )
 
     const numFrozenColumns = this.state.frozenColumns.length
 
     return (
       <div className="bp-datatable-wrapper">
-        <ChevronRight className={`bp-datatable-wrapper-options-icon ${this.state.options.isOpen ? "bp-datatable-wrapper-options-icon-open rotate-90-cw" : "bp-datatable-wrapper-options-icon-closed rotate--90-cw"}`} />
-        <div className="bp-datatable-wrapper-title" style={{ display: "flex", flexDirection: "horizontal" }} onMouseEnter={() => this.setState({ options: { ...this.state.options, isOpen: true } })} onMouseLeave={() => this.setState({ options: { ...this.state.options, isOpen: false } })}>
+        <ChevronRight
+          className={`bp-datatable-wrapper-options-icon ${
+            this.state.options.isOpen ? "bp-datatable-wrapper-options-icon-open rotate-90-cw" : "bp-datatable-wrapper-options-icon-closed rotate--90-cw"
+          }`}
+        />
+        <div
+          className="bp-datatable-wrapper-title"
+          style={{ display: "flex", flexDirection: "horizontal" }}
+          onMouseEnter={() => this.setState({ options: { ...this.state.options, isOpen: true } })}
+          onMouseLeave={() => this.setState({ options: { ...this.state.options, isOpen: false } })}
+        >
           <Collapse isOpen={this.state.options.isOpen}>
             <Stack direction="horizontal" gap={3} style={{ position: "relative", top: "-5px", right: "0px" }}>
               <Button
@@ -908,14 +942,18 @@ export class DataTableWrapperBPClass extends React.PureComponent<{}, {}> {
       rowIndex = sortedRowIndex // if the sorted row index is not null, set the row index to the sorted row index
     }
 
-    return <EditableCell2 intent={this.state.sparseCellIntent[`${rowIndex}-${[this.state.columnIndexMap[columnIndex]]}`]}
-                          value={this.getCellData(rowIndex, columnIndex)}
-                          onCancel={this.cellValidator(rowIndex, columnIndex)}
-                          onChange={(newValue) => {
-                            this.handleCellChange(rowIndex, columnIndex, newValue);
-                            this.cellValidator(rowIndex, columnIndex)(newValue);
-                          }}
-                          onConfirm={this.cellSetter(rowIndex, columnIndex)}></EditableCell2>
+    return (
+      <EditableCell2
+        intent={this.state.sparseCellIntent[`${rowIndex}-${[this.state.columnIndexMap[columnIndex]]}`]}
+        value={this.getCellData(rowIndex, columnIndex)}
+        onCancel={this.cellValidator(rowIndex, columnIndex)}
+        onChange={(newValue) => {
+          this.handleCellChange(rowIndex, columnIndex, newValue)
+          this.cellValidator(rowIndex, columnIndex)(newValue)
+        }}
+        onConfirm={this.cellSetter(rowIndex, columnIndex)}
+      ></EditableCell2>
+    )
   }
 
   /**
@@ -924,7 +962,15 @@ export class DataTableWrapperBPClass extends React.PureComponent<{}, {}> {
    * @returns columnNameRenderer - column name renderer
    */
   private getColumnNameRenderer = (name: string, columnIndex: number) => {
-    return <EditableName index={columnIndex} name={this.getName(columnIndex)} onCancel={this.columnNameValidator(columnIndex)} onChange={this.columnNameValidator(columnIndex)} onConfirm={this.columnNameSetter(columnIndex)} />
+    return (
+      <EditableName
+        index={columnIndex}
+        name={this.getName(columnIndex)}
+        onCancel={this.columnNameValidator(columnIndex)}
+        onChange={this.columnNameValidator(columnIndex)}
+        onConfirm={this.columnNameSetter(columnIndex)}
+      />
+    )
   }
 
   /**
@@ -1026,8 +1072,8 @@ export class DataTableWrapperBPClass extends React.PureComponent<{}, {}> {
    * @param newValue - new value
    */
   private handleCellChange = (rowIndex: number, columnIndex: number, newValue: string) => {
-    const dataKey = this.dataKey(rowIndex, columnIndex);
-    this.setSparseState("sparseCellData", dataKey, newValue);
+    const dataKey = this.dataKey(rowIndex, columnIndex)
+    this.setSparseState("sparseCellData", dataKey, newValue)
   }
 
   /**


### PR DESCRIPTION
Il y avait un bug ou c'était impossible de changer les valeurs dans le data-table d'un fichier .csv directement: j'ai réussi à fix le bug. Aussi, quand on modifie une valeur (int) vers une autre valeur (float) en utilisant une virgule pour le float, le data-table le traitait comme une autre colonne et ca retournait une erreur quand j'ouvrais le fichier .csv après avoir sauvegarder. Pour fix ce bug, j'ai ajouter une logique qui regarde si la nouvelle valeur contient une virgule, si oui, je la change en point. 