### PR TITLE
CTRL+S shortcut to save scenes and code editor

### DIFF
--- a/renderer/components/flow/codeEditor.jsx
+++ b/renderer/components/flow/codeEditor.jsx
@@ -153,13 +153,13 @@ const CodeEditor = ({id, path, updateSavedCode}) => {
         else {
           setSaved(true)
           updateSavedCode(true, id)
-          toast.success("Saved file successfully")
+          toast.success("Saved " + globalData[id].name + " file successfully")
         }
       },
       (error) => {
         setLoadingSave(false)
         console.error("Error from backend:", error)
-        toast.error("Error saving file")
+        toast.error("Error saving file " + globalData[id].name)
       }
     )
   })
@@ -215,21 +215,20 @@ const CodeEditor = ({id, path, updateSavedCode}) => {
     fetchFile(id, path)
   }, [id, path])
 
-  // Add the key event listener
+  // Add CTRL+S event listener (fired in main container) to save changes
   useEffect(() => {
-    const handleKeyDown = (event) => {
-      if ((event.ctrlKey || event.metaKey) && event.key === 's') {
-        event.preventDefault() // Prevent browser's save dialog
-        saveChanges()
+      const handleSaveEvent = (event) => {
+        if (id === event.detail?.tabId ) {
+          saveChanges()
+        }
       }
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    
-    // Cleanup function to remove event listener when component unmounts
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [saveChanges])
+      document.body.addEventListener('saveFileEvent', handleSaveEvent)
+      
+      // Cleanup function to remove event listener when component unmounts
+      return () => {
+        document.body.removeEventListener('saveFileEvent', handleSaveEvent)
+      }
+    }, [saveChanges])
 
   return (
     <>

--- a/renderer/components/flow/codeEditor.jsx
+++ b/renderer/components/flow/codeEditor.jsx
@@ -159,7 +159,7 @@ const CodeEditor = ({id, path, updateSavedCode}) => {
       (error) => {
         setLoadingSave(false)
         console.error("Error from backend:", error)
-        toast.error("Error saving file " + globalData[id].name)
+        toast.error("Error saving file: " + globalData[id].name)
       }
     )
   })

--- a/renderer/components/layout/flexlayout/mainContainerClass.tsx
+++ b/renderer/components/layout/flexlayout/mainContainerClass.tsx
@@ -135,6 +135,16 @@ class MainInnerContainer extends React.Component<any, { layoutFile: string | nul
     }
   }
 
+  handleSaveTab = (event) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault() // Prevent browser's save dialog
+      const tabToSave = this.state.model?.getActiveTabset()?.getSelectedNode() as TabNode
+      if (tabToSave) {
+        document.body.dispatchEvent(new CustomEvent("saveFileEvent", { detail: { tabId: tabToSave.getId() } }))
+      }
+    }
+  }
+
   /**
    * Callback when the component is mounted
    * @returns nothing
@@ -143,6 +153,7 @@ class MainInnerContainer extends React.Component<any, { layoutFile: string | nul
   componentDidMount() {
     this.loadLayout("default", false)
     document.body.addEventListener("touchmove", this.preventIOSScrollingWhenDragging, { passive: false })
+    document.body.addEventListener('keydown', this.handleSaveTab)
     const { layoutRequestQueue, setLayoutRequestQueue } = this.context as LayoutContextType
     if (layoutRequestQueue.length > 0) {
       layoutRequestQueue.forEach((action) => {
@@ -154,6 +165,15 @@ class MainInnerContainer extends React.Component<any, { layoutFile: string | nul
       })
       setLayoutRequestQueue([])
     }
+  }
+
+  /**
+   * Callback when the component is unmounted
+   * @returns nothing
+   * @summary Removes the save shortcut event listener
+   */
+  componentWillUnmount(): void {
+    document.body.removeEventListener('keydown', this.handleSaveTab)
   }
 
   /**

--- a/renderer/components/learning/workflow.jsx
+++ b/renderer/components/learning/workflow.jsx
@@ -786,7 +786,7 @@ const Workflow = ({ setWorkflowType, workflowType }) => {
       if (success) {
         toast.success("Scene " + sceneName + " has been saved successfully")
       } else {
-        toast.error("Error while saving scene" + sceneName)
+        toast.error("Error while saving scene: " + sceneName)
       }
     }
   }, [reactFlowInstance, MLType, intersections])

--- a/renderer/components/learning/workflow.jsx
+++ b/renderer/components/learning/workflow.jsx
@@ -775,7 +775,6 @@ const Workflow = ({ setWorkflowType, workflowType }) => {
    * save the workflow as a json file
    */
   const onSave = useCallback(async () => {
-    console.log("savedTest")
     if (reactFlowInstance && metadataFileID) {
       const flow = deepCopy(reactFlowInstance.toObject())
       flow.MLType = MLType

--- a/renderer/components/learning/workflow.jsx
+++ b/renderer/components/learning/workflow.jsx
@@ -784,30 +784,30 @@ const Workflow = ({ setWorkflowType, workflowType }) => {
       flow.intersections = intersections
       let success = await overwriteMEDDataObjectContent(metadataFileID, [flow])
       if (success) {
-        toast.success("Scene has been saved successfully")
+        toast.success("Scene " + sceneName + " has been saved successfully")
       } else {
-        toast.error("Error while saving scene")
+        toast.error("Error while saving scene" + sceneName)
       }
     }
   }, [reactFlowInstance, MLType, intersections])
 
   /**
-   * Handle using CTRL+S to save
+   * Add CTRL+S event listener (fired in main container) to save changes
    */
-    useEffect(() => {
-      const handleKeyDown = (event) => {
-        if ((event.ctrlKey || event.metaKey) && event.key === 's') {
-          event.preventDefault() // Prevent browser's save dialog
-          onSave()
-        }
+  useEffect(() => {
+    const handleSaveEvent = (event) => {
+      if (globalData[pageId]?.id === event.detail?.tabId ) {
+        onSave()
       }
-      window.addEventListener('keydown', handleKeyDown)
-      
-      // Cleanup function to remove event listener when component unmounts
-      return () => {
-        window.removeEventListener('keydown', handleKeyDown)
-      }
-    }, [onSave])
+    }
+    document.body.addEventListener('saveFileEvent', handleSaveEvent)
+    
+    // Cleanup function to remove event listener when component unmounts
+    return () => {
+      document.body.removeEventListener('saveFileEvent', handleSaveEvent)
+    }
+  }, [onSave])
+
 
 
   /**

--- a/renderer/components/learning/workflow.jsx
+++ b/renderer/components/learning/workflow.jsx
@@ -775,6 +775,7 @@ const Workflow = ({ setWorkflowType, workflowType }) => {
    * save the workflow as a json file
    */
   const onSave = useCallback(async () => {
+    console.log("savedTest")
     if (reactFlowInstance && metadataFileID) {
       const flow = deepCopy(reactFlowInstance.toObject())
       flow.MLType = MLType
@@ -790,6 +791,25 @@ const Workflow = ({ setWorkflowType, workflowType }) => {
       }
     }
   }, [reactFlowInstance, MLType, intersections])
+
+  /**
+   * Handle using CTRL+S to save
+   */
+    useEffect(() => {
+      const handleKeyDown = (event) => {
+        if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+          event.preventDefault() // Prevent browser's save dialog
+          onSave()
+        }
+      }
+      window.addEventListener('keydown', handleKeyDown)
+      
+      // Cleanup function to remove event listener when component unmounts
+      return () => {
+        window.removeEventListener('keydown', handleKeyDown)
+      }
+    }, [onSave])
+
 
   /**
    * Clear the canvas if the user confirms


### PR DESCRIPTION
CTRL+S can now be used to save code editor files and learning scenes
It will only save the active tab according to the maincontainer class, a.k.a. the last one that has been clicked on or interacted with (with the exception of click-dragging on a scene, which does not give "focus" to its tab)

Linked to https://github.com/MEDomics-UdeS/MEDomicsLab/issues/86 