### PR TITLE
Evaluation Module 

### DIFF
--- a/renderer/components/evaluation/evaluationPageContent.jsx
+++ b/renderer/components/evaluation/evaluationPageContent.jsx
@@ -5,7 +5,7 @@ import { requestBackend } from "../../utilities/requests"
 import { getCollectionData } from "../dbComponents/utils"
 import { LoaderContext } from "../generalPurpose/loaderContext"
 import { PageInfosContext } from "../mainPages/moduleBasics/pageInfosContext"
-import { getCollectionColumns, overwriteMEDDataObjectContent } from "../mongoDB/mongoDBUtils"
+import { getCollectionColumns, overwriteMEDDataObjectContent, deleteMEDDataObject } from "../mongoDB/mongoDBUtils"
 import { DataContext } from "../workspace/dataContext"
 import { MEDDataObject } from "../workspace/NewMedDataObject"
 import { WorkspaceContext } from "../workspace/workspaceContext"
@@ -73,9 +73,14 @@ const EvaluationPageContent = () => {
    * @description - This function is used to update the config WHEN THE USER CLICKS ON THE UPDATE CONFIG BUTTON
    */
   const updateConfigClick = async () => {
+    console.log("called updateConfigClick")
     let config = { ...evalConfig }
     config["isSet"] = true
     setEvalConfig(config)
+    let predictionFileID = MEDDataObject.getChildIDWithName(globalData, pageId, "predictions.csv")
+    if (predictionFileID) {
+      await deleteMEDDataObject(predictionFileID)
+    }
     let configToLoadID = MEDDataObject.getChildIDWithName(globalData, pageId, "metadata.json")
     let success = await overwriteMEDDataObjectContent(configToLoadID, [config])
     if (success) {
@@ -231,6 +236,16 @@ const EvaluationPageContent = () => {
   }
 
   /**
+   * @description Function used to disable the create evaluation button if the fields are empty
+   */
+  const checkForEmptyInput = () => {
+    return (chosenDataset == {} ||
+            chosenDataset.selectedDatasets?.length == 0 ||
+            chosenModel == {} ||
+            chosenModel.id == '')
+  }
+
+  /**
    *
    * @returns the evaluation step: either the config step or the evaluation step
    */
@@ -267,6 +282,7 @@ const EvaluationPageContent = () => {
           updateConfigClick={updateConfigClick}
           setChosenModel={setChosenModel}
           setChosenDataset={setChosenDataset}
+          checkForEmptyInput={checkForEmptyInput}
         />
       )
     }

--- a/renderer/components/evaluation/pageConfig.jsx
+++ b/renderer/components/evaluation/pageConfig.jsx
@@ -18,6 +18,7 @@ import { Tooltip } from "primereact/tooltip"
  * @param {Object} datasetHasWarning Object containing the dataset warning state and tooltip
  * @param {Function} setDatasetHasWarning Function to set the dataset warning state and tooltip
  * @param {Function} updateConfigClick Function to update the config on click
+ * @param {Function} checkForEmptyInput Function to check if model or dataset inputs are not set
  *
  * @returns the configuation page of the evaluation page
  */
@@ -32,7 +33,8 @@ const PageConfig = ({
   datasetHasWarning,
   setDatasetHasWarning,
   updateConfigClick,
-  useMedStandard
+  useMedStandard,
+  checkForEmptyInput
 }) => {
   // on load check if there is a config
 
@@ -53,7 +55,7 @@ const PageConfig = ({
   // footer template
   const footer = (
     <>
-      <Button label="Create evaluation" icon="pi pi-arrow-right" iconPos="right" disabled={modelHasWarning.state || datasetHasWarning.state} onClick={updateConfigClick} />
+      <Button label="Create evaluation" icon="pi pi-arrow-right" iconPos="right" disabled={checkForEmptyInput() || modelHasWarning.state || datasetHasWarning.state} onClick={updateConfigClick} />
     </>
   )
 

--- a/renderer/components/evaluation/pageEval.jsx
+++ b/renderer/components/evaluation/pageEval.jsx
@@ -12,6 +12,7 @@ import Input from "../learning/input"
 import { WorkspaceContext } from "../workspace/workspaceContext"
 import Dashboard from "./dashboard"
 import PredictPanel from "./predictPanel"
+import { findMEDDataObjectsByName } from "../mongoDB/mongoDBUtils"
 
 /**
  *@param {Object} run Object containing the run state and the run function
@@ -82,7 +83,28 @@ const PageEval = ({ run, pageId, config, updateWarnings, setChosenModel, updateC
 
   // when the run changes, we start the evaluation processes
   useEffect(() => {
-    startCalls2Server()
+    const findStoredData = async () => {
+      var foundData = false
+
+      // Find if data is already saved in child object of current page
+      const documents = await findMEDDataObjectsByName("predictions.csv")
+      console.log("pageId: ", pageId)
+      await documents.forEach((doc) => {
+        console.log("doc: ", doc)
+        if (pageId === doc.parentID) {
+          console.log("Found predictions.csv for pageID: ", pageId, "with doc:", doc)
+          setPredictedData({"collection_id": doc.id})
+          foundData = true
+        }
+      })
+      console.log("Found data: ", foundData)
+      // If not found, create it
+      if (!foundData) {
+        startCalls2Server()
+      }
+    }
+
+    findStoredData()
   }, [run])
 
   /**

--- a/renderer/components/layout/sidebarTools/pageSidebar/evaluationSidebar.jsx
+++ b/renderer/components/layout/sidebarTools/pageSidebar/evaluationSidebar.jsx
@@ -29,6 +29,7 @@ const EvaluationSidebar = () => {
   // We use the useEffect hook to update the experiment list state when the workspace changes
   useEffect(() => {
     let localExperimentList = []
+    if (!globalData["EXPERIMENTS"]) return
     for (const experimentId of globalData["EXPERIMENTS"].childrenIDs) {
       localExperimentList.push(globalData[experimentId].name)
     }

--- a/renderer/components/layout/sidebarTools/pageSidebar/flowSceneSidebar.jsx
+++ b/renderer/components/layout/sidebarTools/pageSidebar/flowSceneSidebar.jsx
@@ -35,6 +35,7 @@ const FlowSceneSidebar = ({ type }) => {
   // We use the useEffect hook to update the experiment list state when the workspace changes
   useEffect(() => {
     let localExperimentList = []
+    if (!globalData["EXPERIMENTS"]) return
     for (const experimentId of globalData["EXPERIMENTS"].childrenIDs) {
       localExperimentList.push(globalData[experimentId].name)
     }

--- a/renderer/components/mongoDB/mongoDBUtils.js
+++ b/renderer/components/mongoDB/mongoDBUtils.js
@@ -546,6 +546,19 @@ export async function findMEDDataObjectByName(name) {
 }
 
 /**
+ * @description Get MEDDataObjects specified by name from the DB in case of multiple objects with identical names
+ * @param {*} name
+ * @returns
+ */
+export async function findMEDDataObjectsByName(name) {
+  const db = await connectToMongoDB()
+  const collection = db.collection("medDataObjects")
+  const query = { name: name }
+  const documents = await collection.find(query)
+  return documents
+}
+
+/**
  * @description Get the MEDDataObject specified by path from the DB
  * @param {*} path // path of the MEDDataObject
  * @param {*} type // type of the MEDDataObject


### PR DESCRIPTION
Linked to [#333](https://github.com/MEDomics-UdeS/MEDomicsLab/issues/333)

If the .medeval object loaded in a tab already has an existing predictions.csv child, it will be loaded instead of recalculating it when  opening the tab. Clicking the generate evaluation button will delete this file so that it is recreated after the backend request.

Also fixed 2 bugs:
- If the workspace has no experiments generated, clicking on the evaluation sidebar icon would crash, but not anymore
- In the .medeval config page, if neither field were selected, the "generate evaluation" button could still be clicked, giving errors due to the dataset and model not being selected. The button now checks if those fields have something selected before enabling itself